### PR TITLE
Test Containers Arch

### DIFF
--- a/tests/integration/budget-item_test.go
+++ b/tests/integration/budget-item_test.go
@@ -29,7 +29,7 @@ func TestBudgetItem(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(6*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/budget-item_test.go
+++ b/tests/integration/budget-item_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -23,14 +22,14 @@ import (
 func TestBudgetItem(t *testing.T) {
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testbudgetitem"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(6*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),
@@ -147,7 +146,6 @@ func TestBudgetItem(t *testing.T) {
 		t.Run("it should get all budget-items by accumulate", func(t *testing.T) {
 			var parentUUID *uuid.UUID = nil
 			budgetItems := s.DB.GetBudgetItemsByAccumulate(companyId, true)
-			slog.Info("single budget item", "budgetItems", budgetItems)
 			assert.Equal(t, 1, len(budgetItems))
 			assert.Equal(t, budgetItems[0].Name, "Costo Directo")
 			assert.Equal(t, budgetItems[0].Code, "500")

--- a/tests/integration/budget_test.go
+++ b/tests/integration/budget_test.go
@@ -38,7 +38,7 @@ func TestBudget(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(6*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/budget_test.go
+++ b/tests/integration/budget_test.go
@@ -31,14 +31,14 @@ func TestBudget(t *testing.T) {
 
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testbudget"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(6*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/categories_test.go
+++ b/tests/integration/categories_test.go
@@ -20,14 +20,14 @@ import (
 func TestCategories(t *testing.T) {
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testcategories"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(6*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/categories_test.go
+++ b/tests/integration/categories_test.go
@@ -27,7 +27,7 @@ func TestCategories(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(6*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/edit_budget_test.go
+++ b/tests/integration/edit_budget_test.go
@@ -38,7 +38,7 @@ func TestUpdateBudget(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(6*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/edit_budget_test.go
+++ b/tests/integration/edit_budget_test.go
@@ -31,14 +31,14 @@ func TestUpdateBudget(t *testing.T) {
 
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testupdatebudget"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(6*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/invoice-details_test.go
+++ b/tests/integration/invoice-details_test.go
@@ -32,7 +32,7 @@ func TestInvoiceDetails(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(6*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/invoice-details_test.go
+++ b/tests/integration/invoice-details_test.go
@@ -25,14 +25,14 @@ import (
 func TestInvoiceDetails(t *testing.T) {
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testinvoicedetails"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(6*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/invoice_test.go
+++ b/tests/integration/invoice_test.go
@@ -27,7 +27,7 @@ func TestInvoice(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(6*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/invoice_test.go
+++ b/tests/integration/invoice_test.go
@@ -20,14 +20,14 @@ import (
 func TestInvoice(t *testing.T) {
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testunitcost"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(6*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/login_test.go
+++ b/tests/integration/login_test.go
@@ -29,7 +29,7 @@ func TestLogin(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(6*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/login_test.go
+++ b/tests/integration/login_test.go
@@ -22,14 +22,14 @@ import (
 func TestLogin(t *testing.T) {
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:16.4-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(6*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/materials_test.go
+++ b/tests/integration/materials_test.go
@@ -27,7 +27,7 @@ func TestMaterials(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(6*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/materials_test.go
+++ b/tests/integration/materials_test.go
@@ -20,14 +20,14 @@ import (
 func TestMaterials(t *testing.T) {
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testmaterials"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(6*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/projects_test.go
+++ b/tests/integration/projects_test.go
@@ -20,14 +20,14 @@ import (
 func TestProjects(t *testing.T) {
 	ctx := context.Background()
 	pgContaineer, err := postgres.Run(ctx,
-		"postgres:16.4-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testproject"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),
@@ -105,7 +105,7 @@ func TestProjects(t *testing.T) {
 	})
 
 	t.Run("single project", func(t *testing.T) {
-    companyId := getCompanyId(t, s, cookies)
+		companyId := getCompanyId(t, s, cookies)
 
 		projects, err := s.DB.GetAllProjects(companyId)
 		assert.NoError(t, err)

--- a/tests/integration/rubros_test.go
+++ b/tests/integration/rubros_test.go
@@ -20,14 +20,14 @@ import (
 func TestRubros(t *testing.T) {
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testrubros"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/suppliers_test.go
+++ b/tests/integration/suppliers_test.go
@@ -20,14 +20,14 @@ import (
 func TestSuppliers(t *testing.T) {
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testproject"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),

--- a/tests/integration/users_test.go
+++ b/tests/integration/users_test.go
@@ -22,14 +22,14 @@ import (
 func TestUsers(t *testing.T) {
 	ctx := context.Background()
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:14.1-alpine",
+		"postgres:16-alpine",
 		postgres.WithDatabase("testusers"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second),
+				WithStartupTimeout(10*time.Second),
 		),
 		postgres.WithInitScripts(filepath.Join("..", "..", "internal", "database", "tables.sql")),
 		postgres.WithInitScripts(filepath.Join("scripts", "u000-company.sql")),


### PR DESCRIPTION
Sometimes, when running the tests locally, it might get timeout errors.

That is not acceptable since for developing we need to run our tests locally to see if those work properly.  

In order to achieve that I've incremented the timeout during the container creation.
